### PR TITLE
add name field to metadata.rb

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name "xslt"
 maintainer       "Phil Cohen"
 maintainer_email "github@phlippers.net"
 license          "MIT"


### PR DESCRIPTION
New version chef requires name field in `metadata.rb` or it would cause error on installing cookbook.
